### PR TITLE
Fix #8: Migrate audio recordings from volatile cacheDir to persistent external storage

### DIFF
--- a/app/src/main/java/com/larsson/voicenote_android/features/audiorecorder/Recorder.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/features/audiorecorder/Recorder.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.media.MediaMetadataRetriever
 import android.media.MediaRecorder
 import android.os.Build
+import android.os.Environment
 import android.util.Log
 import java.io.File
 
@@ -31,7 +32,7 @@ class Recorder(private val context: Context) : AudioRecorder {
     }
 
     fun startRecording(fileName: String): File {
-        val file = File(context.cacheDir, fileName)
+        val file = File(context.getExternalFilesDir(Environment.DIRECTORY_RECORDINGS), fileName)
         Log.d(TAG, "fileName: $fileName")
         start(file)
         return file
@@ -74,7 +75,7 @@ class Recorder(private val context: Context) : AudioRecorder {
     private fun fetchMetaDataDuration() {
         val metadataRetriever = MediaMetadataRetriever()
         try {
-            metadataRetriever.setDataSource("${context.cacheDir}/${audioFile?.name}")
+            metadataRetriever.setDataSource("${context.getExternalFilesDir(Environment.DIRECTORY_RECORDINGS)}/${audioFile?.name}")
             metadataDuration = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
         } catch (e: Exception) {
             Log.e(TAG, "Error setting dataSource when retrieving metadata. Error: ${e.message}")
@@ -83,7 +84,7 @@ class Recorder(private val context: Context) : AudioRecorder {
 
 
     fun deleteRecording(fileName: String) {
-        File(context.cacheDir, fileName).delete()
+        File(context.getExternalFilesDir(Environment.DIRECTORY_RECORDINGS), fileName).delete()
     }
 
     override fun pause() {

--- a/audioplayer/src/main/java/com/larsson/voicenote_android/audioplayer/LocalAudioPlayer.kt
+++ b/audioplayer/src/main/java/com/larsson/voicenote_android/audioplayer/LocalAudioPlayer.kt
@@ -3,6 +3,7 @@ package com.larsson.voicenote_android.audioplayer
 import android.content.ComponentName
 import android.content.Context
 import android.net.Uri
+import android.os.Environment
 import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
@@ -109,7 +110,7 @@ class LocalAudioPlayer(
 
     private fun setMediaItem(recordingId: String) {
         try {
-            val file = File(context.cacheDir, recordingId)
+            val file = File(context.getExternalFilesDir(Environment.DIRECTORY_RECORDINGS), recordingId)
 
             val item = MediaItem.Builder()
                 .setUri(Uri.fromFile(file))


### PR DESCRIPTION
## Summary
Migrates audio recording storage from volatile `cacheDir` to persistent external storage to prevent unexpected data loss when the system clears cache.

## Changes
- **Recorder.kt**: Updated 3 locations to use `getExternalFilesDir(DIRECTORY_RECORDINGS)`
  - Recording creation (`startRecording`)
  - Metadata retrieval (`fetchMetaDataDuration`)
  - File deletion (`deleteRecording`)
- **LocalAudioPlayer.kt**: Updated playback to load from new persistent location
- Added `Environment` import for `DIRECTORY_RECORDINGS` constant

## Benefits
✅ Recordings are now persistent (only deleted on app uninstall)
✅ User-accessible location via file manager (`/Android/data/.../files/Recordings`)
✅ No additional permissions required (app-specific external storage)
✅ Prevents system from clearing recordings unexpectedly

## Testing
- [ ] Verify new recordings are created in correct location
- [ ] Verify playback works with new storage location
- [ ] Verify deletion works correctly
- [ ] Confirm recordings persist after app restart

Fixes #8