### PR TITLE
Fix #11: Enable database schema export for version tracking and migration safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /.idea/other.xml
 /.idea/runConfigurations.xml
 /.idea/kotlinc.xml
+/.idea/deviceManager.xml
 .DS_Store
 /build
 /captures

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
     id("kotlin-kapt")
     alias(libs.plugins.jetbrains.kotlin.serialization)
+    alias(libs.plugins.androidx.room)
 }
 android {
     namespace = "com.larsson.voicenote_android"
@@ -45,10 +46,16 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    room {
+        schemaDirectory("$projectDir/schemas")
+    }
+
 }
 
 dependencies {
     implementation(project(":audioplayer"))
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
@@ -93,8 +100,6 @@ dependencies {
 
     // Room
     implementation(libs.bundles.room)
-//    implementation(libs.androidx.room.ktx)
     kapt(libs.androidx.room.compiler)
-//    implementation(libs.androidx.room.runtime)
     annotationProcessor(libs.androidx.room.compiler)
 }

--- a/app/schemas/com.larsson.voicenote_android.data.room.NoteDatabase/9.json
+++ b/app/schemas/com.larsson.voicenote_android.data.room.NoteDatabase/9.json
@@ -1,0 +1,102 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "f4229686e81a0de5d2e52ec0034d7300",
+    "entities": [
+      {
+        "tableName": "NOTES_TABLE",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`noteId` TEXT NOT NULL, `note_title` TEXT NOT NULL, `note_desc` TEXT NOT NULL, `date` TEXT NOT NULL, PRIMARY KEY(`noteId`))",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteTitle",
+            "columnName": "note_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteTxtContent",
+            "columnName": "note_desc",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "noteId"
+          ]
+        }
+      },
+      {
+        "tableName": "RECORDINGS_TABLE",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recordingId` TEXT NOT NULL, `recording_number` INTEGER NOT NULL, `recording_title` TEXT, `recording_link` TEXT NOT NULL, `recording_date` TEXT NOT NULL, `recording_duration` TEXT NOT NULL, `noteId` TEXT NOT NULL, PRIMARY KEY(`recordingId`))",
+        "fields": [
+          {
+            "fieldPath": "recordingId",
+            "columnName": "recordingId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordingNumber",
+            "columnName": "recording_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordingTitle",
+            "columnName": "recording_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recordingLink",
+            "columnName": "recording_link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordingDate",
+            "columnName": "recording_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordingDuration",
+            "columnName": "recording_duration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recordingId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f4229686e81a0de5d2e52ec0034d7300')"
+    ]
+  }
+}

--- a/app/src/main/java/com/larsson/voicenote_android/data/room/NoteDatabase.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/data/room/NoteDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import com.larsson.voicenote_android.data.entity.NoteEntity
 import com.larsson.voicenote_android.data.entity.RecordingEntity
 
-@Database(entities = [NoteEntity::class, RecordingEntity::class], version = 9, exportSchema = false)
+@Database(entities = [NoteEntity::class, RecordingEntity::class], version = 9)
 abstract class NoteDatabase : RoomDatabase() {
     abstract fun noteDao(): NoteDao
     abstract fun recordingDao(): RecordingDao
@@ -25,7 +25,7 @@ abstract class NoteDatabase : RoomDatabase() {
                         context.applicationContext,
                         NoteDatabase::class.java,
                         "notes_database",
-                    ).fallbackToDestructiveMigration()
+                    ).fallbackToDestructiveMigration(true)
                         .build()
 
                     INSTANCE = instance

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,3 +74,4 @@ room = ["androidx-room-ktx", "androidx-room-runtime"]
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinSerialization"}
+androidx-room = { id = "androidx.room", version.ref = "roomKtx" }


### PR DESCRIPTION
## Summary
Enables Room database schema export to track database structure changes across versions and improve migration safety.

## Changes
- **Version Catalog (`libs.versions.toml`)**: Added Room Gradle plugin definition
- **Build Configuration (`app/build.gradle.kts`)**: 
  - Applied Room plugin
  - Configured schema directory location (`$projectDir/schemas`)
  - Cleaned up commented Room dependencies
- **Database (`NoteDatabase.kt`)**: 
  - Removed `exportSchema = false` (defaults to `true`)
  - Updated `fallbackToDestructiveMigration()` to non-deprecated signature with `dropAllTables = true`
- **Schema Files**: Generated and committed schema file for database version 9
- **Git Ignore**: Added `deviceManager.xml` to ignore list

## Benefits
✅ Schema history tracked in version control for reference
✅ Easier to verify migration correctness
✅ Better debugging of database issues
✅ Documentation of schema evolution over time
✅ Room can validate migrations against schema files

## Database Schema (Version 9)
The committed schema shows:
- **NOTES_TABLE**: noteId, note_title, note_desc, date
- **RECORDINGS_TABLE**: recordingId, recording_number, recording_title, recording_link, recording_date, recording_duration, noteId

## Testing
- [x] Build succeeds with schema export enabled
- [x] Schema file generated at `app/schemas/.../9.json`
- [x] App runs without issues

Fixes #11