### PR TITLE
Add foreign key constraint and make noteId nullable in RecordingEntity

### DIFF
--- a/app/src/main/java/com/larsson/voicenote_android/data/entity/RecordingEntity.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/data/entity/RecordingEntity.kt
@@ -2,12 +2,23 @@ package com.larsson.voicenote_android.data.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.ForeignKey.Companion.SET_NULL
 import androidx.room.PrimaryKey
 import com.larsson.voicenote_android.data.repository.Recording
 
 const val RECORDINGS_TABLE = "RECORDINGS_TABLE"
 
-@Entity(tableName = RECORDINGS_TABLE)
+@Entity(
+    tableName = RECORDINGS_TABLE,
+    // If you set noteId on a recording, that note must exist.
+    foreignKeys = [ForeignKey(
+        entity = NoteEntity::class,
+        parentColumns = ["noteId"], // Column in NoteEntity
+        childColumns = ["noteId"], // Column in RecordingEntity
+        onDelete = SET_NULL // When note deleted, keep recording but set noteId = null
+    )]
+)
 data class RecordingEntity(
     @PrimaryKey(autoGenerate = false) @ColumnInfo val recordingId: String,
     @ColumnInfo(name = "recording_number")
@@ -21,7 +32,7 @@ data class RecordingEntity(
     @ColumnInfo(name = "recording_duration")
     val recordingDuration: String,
     @ColumnInfo(name = "noteId")
-    val noteId: String
+    val noteId: String?
 )
 
 fun List<RecordingEntity>.toRecordings(): List<Recording> {

--- a/app/src/main/java/com/larsson/voicenote_android/data/repository/RecordingsRepository.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/data/repository/RecordingsRepository.kt
@@ -28,7 +28,7 @@ class RecordingsRepository(private val recordingDao: RecordingDao) {
         return recordingDao.getNumberOfRecordings().map { it?.plus(1) ?: 1 }
     }
 
-    suspend fun stopRecording(id: String, link: String, duration: String, noteId: String) {
+    suspend fun stopRecording(id: String, link: String, duration: String, noteId: String?) {
         val dateTimeString = LocalDateTime.now().toString()
         addRecording(
             recording = Recording(
@@ -67,6 +67,6 @@ data class Recording(
     val date: String,
     val duration: String,
     val id: String,
-    val noteId: String,
+    val noteId: String?,
     val recordingNumber: Int,
 )

--- a/app/src/main/java/com/larsson/voicenote_android/viewmodels/RecordingViewModel.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/viewmodels/RecordingViewModel.kt
@@ -48,7 +48,7 @@ class RecordingViewModel(
         return recordingsRepo.getRecordingsTiedToNoteById(id = id).map { it.reversed() }
     }
 
-    fun stopRecording(noteId: String? = "0000") {
+    fun stopRecording(noteId: String?) {
         val id = getLocalUUID()
         recorder.stop()
 
@@ -57,7 +57,7 @@ class RecordingViewModel(
                 id = id,
                 link = audioFile?.path.toString(),
                 duration = recorder.getMetadataDuration(),
-                noteId = noteId ?: "0000"
+                noteId = noteId
             )
         }
 


### PR DESCRIPTION
## Summary
- Adds foreign key constraint between RecordingEntity and NoteEntity to enforce referential integrity at the database level
- Makes noteId nullable to support both standalone recordings and note-linked recordings
- Removes "0000" sentinel value anti-pattern in favor of proper null handling
- Sets onDelete = SET_NULL to preserve recordings when their parent note is deleted

## Changes
- **RecordingEntity**: Added ForeignKey constraint and made noteId nullable
- **RecordingsRepository**: Updated stopRecording() to accept nullable noteId
- **RecordingViewModel**: Removed "0000" default parameter and sentinel value logic

## Benefits
- Prevents orphaned recordings at the database level
- Self-documenting relationship between entities
- Type-safe handling of optional note associations
- Automatic cleanup when notes are deleted

Fixes #21