### PR TITLE
Add ability to rename recordings via inline text field

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -2,52 +2,55 @@
 
 You are helping the user create a pull request for their uncommitted changes.
 
-## Instructions
-
-1. **Check for uncommitted changes:**
-   - Run `git diff --stat` to see what files have changed
-   - If no changes, inform the user and stop
-
-2. **Determine branch name:**
-   - Ask the user for a brief description of the changes (or infer from the changes and the previous discussion)
-   - Check if there's a GitHub issue number mentioned in the conversation or provided by the user
-   - Branch naming format:
-     - If issue exists: `feature/{issue-number}-{kebab-case-description}` (e.g., `feature/23-add-search-functionality`)
-     - If no issue: `feature/{kebab-case-description}` (e.g., `feature/add-search-functionality`)
-   - Use "feature/" for new features, "fix/" for bug fixes, "refactor/" for refactoring
-
-3. **Create and checkout branch:**
-   - Run: `git checkout -b {branch-name}`
-
-4. **Stage and commit changes:**
-   - Stage all changes: `git add -A`
-   - Write a clear, concise commit message that:
-     - Starts with a verb in imperative mood (Add, Fix, Update, Refactor, etc.)
-     - Summarizes the main change in one line
-     - Uses bullet points for multiple changes
-   - Commit with: `git commit -m "..."`
-   - DO NOT include Claude co-author attribution
-
-5. **Push to remote:**
-   - Push branch: `git push -u origin {branch-name}`
-
-6. **Create Pull Request:**
-   - Write a SHORT and CONCISE PR:
-     - **Title:** One line summary (max 72 chars)
-     - **Body:**
-       - Brief summary (2-3 sentences max)
-       - Bullet points for key changes (3-5 bullets max)
-       - If issue exists, add "Closes #{issue-number}" or "Fixes #{issue-number}" at the end
-   - Use `gh pr create --base develop --title "..." --body "..."`
-   - The "Closes #X" or "Fixes #X" keyword will automatically link and close the issue when merged
-
-7. **Confirm:**
-   - Share the PR URL with the user
-   - Confirm the branch and issue linkage (if applicable)
-
 ## Important Notes
+
 - Always use `--base develop` when creating PRs (not main)
 - Keep PR title and body concise - avoid lengthy descriptions
 - Use GitHub closing keywords (Closes, Fixes, Resolves) to auto-link issues
 - DO NOT add Claude attribution or co-author tags
 - If user mentions an issue number (e.g., "for issue #23"), use it in the branch name and PR body
+
+## Instructions
+
+1. **Check for uncommitted changes:**
+    - Run `git diff --stat` to see what files have changed
+    - If no changes, inform the user and stop
+
+2. **Determine branch name:**
+    - Ask the user for a brief description of the changes (or infer from the changes and the
+      previous discussion)
+    - Check if there's a GitHub issue number mentioned in the conversation or provided by the user
+    - Branch naming format:
+        - If issue exists: `feature/{issue-number}-{kebab-case-description}` (e.g.,
+          `feature/23-add-search-functionality`)
+        - If no issue: `feature/{kebab-case-description}` (e.g., `feature/add-search-functionality`)
+    - Use "feature/" for new features, "fix/" for bug fixes, "refactor/" for refactoring
+
+3. **Create and checkout branch:**
+    - Run: `git checkout -b {branch-name}`
+
+4. **Stage and commit changes:**
+    - Stage all changes: `git add -A`
+    - Write a clear, concise commit message that:
+        - Starts with a verb in imperative mood (Add, Fix, Update, Refactor, etc.)
+        - Summarizes the main change in one line
+        - Uses bullet points for multiple changes
+    - Commit with: `git commit -m "..."`
+    - DO NOT include Claude co-author attribution
+
+5. **Push to remote:**
+    - Push branch: `git push -u origin {branch-name}`
+
+6. **Create Pull Request:**
+    - Write a SHORT and CONCISE PR:
+        - **Title:** One line summary (max 72 chars)
+        - **Body:**
+            - Brief summary (2-3 sentences max)
+            - Bullet points for key changes (3-5 bullets max)
+            - If issue exists, add "Closes #{issue-number}" or "Fixes #{issue-number}" at the end
+    - Use `gh pr create --base develop --title "..." --body "..."`
+    - The "Closes #X" or "Fixes #X" keyword will automatically link and close the issue when merged
+
+7. **Confirm:**
+    - Share the PR URL with the user
+    - Confirm the branch and issue linkage (if applicable)

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,10 @@
   "permissions": {
     "allow": [
       "Bash(gh issue view:*)",
-      "Bash(gh api:*)"
+      "Bash(gh api:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr view:*)"
     ],
     "deny": [],
     "ask": []

--- a/app/src/main/java/com/larsson/voicenote_android/clicklisteners/UiAudioPlayerClickListener.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/clicklisteners/UiAudioPlayerClickListener.kt
@@ -6,14 +6,16 @@ internal interface UiAudioPlayerClickListener {
     fun onClickPlay(recording: Recording)
     fun onClickPause()
     fun onSeekTo(position: Float)
-    fun onToggleExpandContainer(recordingId: String)
+    fun onCollapsedContainerClicked(recordingId: String)
     fun onClickDelete(recordingId: String)
+    fun onTitleValueChange(title: String, recordingId: String)
 }
 
 internal val previewAudioPlayerClickListener = object : UiAudioPlayerClickListener {
     override fun onClickPlay(recording: Recording) {}
     override fun onClickPause() {}
     override fun onSeekTo(position: Float) {}
-    override fun onToggleExpandContainer(recordingId: String) {}
+    override fun onCollapsedContainerClicked(recordingId: String) {}
     override fun onClickDelete(recordingId: String) {}
+    override fun onTitleValueChange(title: String, recordingId: String) {}
 }

--- a/app/src/main/java/com/larsson/voicenote_android/data/repository/RecordingsRepository.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/data/repository/RecordingsRepository.kt
@@ -58,13 +58,10 @@ class RecordingsRepository(
     }
 
 
-//    fun getRecordingById(id: String): Flow<RecordingEntity> {
+    //    fun getRecordingById(id: String): Flow<RecordingEntity> {
 //        return recordingDao.getRecording(id)
 //    }
-//
-//    fun updateRecording(recordingEntity: RecordingEntity) {
-//        recordingDao.updateRecording(recordingEntity)
-//    }
+
 
     suspend fun deleteRecording(recordingId: String) {
         // Get the recording to retrieve the file path
@@ -79,12 +76,15 @@ class RecordingsRepository(
 
         }
 
-        // Delete from database
         recordingDao.deleteRecording(recordingId)
     }
 
     fun getRecordingsTiedToNoteById(id: String): Flow<List<Recording>> {
         return recordingDao.getRecordingsTiedToNoteById(id = id).map { it.toRecordings() }
+    }
+
+    suspend fun updateTitleById(title: String, id: String) {
+        return recordingDao.updateRecordingTitle(id = id, title = title)
     }
 }
 
@@ -96,7 +96,6 @@ data class Recording(
     val id: String,
     val noteId: String?,
     val recordingNumber: Int,
-//    val fileName: String,
 ) {
     val fileName = "$id.m4a"
 }

--- a/app/src/main/java/com/larsson/voicenote_android/data/room/RecordingDao.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/data/room/RecordingDao.kt
@@ -37,6 +37,9 @@ interface RecordingDao {
     @Update
     fun updateRecording(recordingEntity: RecordingEntity)
 
+    @Query("UPDATE $RECORDINGS_TABLE SET recording_title = :title WHERE recordingId = :id")
+    suspend fun updateRecordingTitle(id: String, title: String)
+
     @Query("DELETE FROM $RECORDINGS_TABLE WHERE recordingId =:recordingId")
     suspend fun deleteRecording(recordingId: String)
 }

--- a/app/src/main/java/com/larsson/voicenote_android/features/EditNoteScreen.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/features/EditNoteScreen.kt
@@ -104,12 +104,16 @@ internal fun EditNoteScreen(
                     audioPlayerViewModel.handleUIEvents(event = AudioPlayerEvent.SeekTo(position))
                 }
 
-                override fun onToggleExpandContainer(recordingId: String) {
-                    audioPlayerViewModel.handleUIEvents(event = AudioPlayerEvent.ToggleExpanded(recordingId))
+                override fun onCollapsedContainerClicked(recordingId: String) {
+                    audioPlayerViewModel.handleUIEvents(event = AudioPlayerEvent.ExpandContainer(recordingId))
                 }
 
                 override fun onClickDelete(recordingId: String) {
                     audioPlayerViewModel.handleUIEvents(event = AudioPlayerEvent.Delete(recordingId))
+                }
+
+                override fun onTitleValueChange(title: String, recordingId: String) {
+                    audioPlayerViewModel.handleUIEvents(event = AudioPlayerEvent.OnTitleValueChange(title = title, recordingId = recordingId))
                 }
 
             }

--- a/app/src/main/java/com/larsson/voicenote_android/features/HomeScreen.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/features/HomeScreen.kt
@@ -70,13 +70,19 @@ fun HomeScreen(
 
             }
 
-            override fun onToggleExpandContainer(recordingId: String) {
-                audioPlayerViewModel.handleUIEvents(event = AudioPlayerEvent.ToggleExpanded(recordingId))
+            override fun onCollapsedContainerClicked(recordingId: String) {
+                audioPlayerViewModel.handleUIEvents(event = AudioPlayerEvent.ExpandContainer(recordingId))
             }
 
             override fun onClickDelete(recordingId: String) {
                 audioPlayerViewModel.handleUIEvents(event = AudioPlayerEvent.Delete(recordingId))
             }
+
+            override fun onTitleValueChange(title: String, recordingId: String) {
+                audioPlayerViewModel.handleUIEvents(event = AudioPlayerEvent.OnTitleValueChange(title = title, recordingId = recordingId))
+            }
+
+
         }
     )
 }

--- a/app/src/main/java/com/larsson/voicenote_android/ui/components/RecordingMenuItem.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/ui/components/RecordingMenuItem.kt
@@ -2,7 +2,6 @@ package com.larsson.voicenote_android.ui.components
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -36,7 +35,6 @@ internal fun RecordingMenuItem(
     id: String,
     durationText: String,
     progress: State<Long>,
-    onToggleExpandContainer: () -> Unit,
     onClickPlay: () -> Unit,
     onClickPause: () -> Unit,
     isFirstItem: Boolean,
@@ -48,10 +46,7 @@ internal fun RecordingMenuItem(
     val interactionSource = remember { MutableInteractionSource() }
     Column(
         modifier = modifier
-            .background(Color.Transparent)
-            .clickable(interactionSource = interactionSource, indication = null) {
-                onToggleExpandContainer()
-            },
+            .background(Color.Transparent),
     ) {
         if (isExpanded) {
             RecordingMenuItemPlayer(
@@ -70,11 +65,13 @@ internal fun RecordingMenuItem(
                 onClickDelete = onClickDelete
             )
         } else {
-            RecordingMenuItemBase(
+            RecordingMenuItemCollapsed(
+                id = id,
                 title = title,
                 date = dateFormatter(date),
                 duration = if (durationText.isNotBlank()) TimeFormatter().timeFormatter(durationText.toLong()) else "",
                 isFirstItem = isFirstItem,
+                onClickExpandContainer = { uiAudioPlayerClickListener.onCollapsedContainerClicked(it) }
             )
         }
     }
@@ -98,8 +95,6 @@ fun RecordingMenuItemPreview() {
                 id = "5",
                 durationText = "240",
                 progress = remember { mutableLongStateOf(40) },
-                onToggleExpandContainer = {
-                },
                 isFirstItem = false,
                 onClickPlay = {},
                 onClickPause = {},
@@ -116,7 +111,6 @@ fun RecordingMenuItemPreview() {
                 id = "5",
                 durationText = "1221",
                 progress = remember { mutableLongStateOf(0L) },
-                onToggleExpandContainer = { },
                 isFirstItem = true,
                 onClickPlay = {},
                 onClickPause = {},

--- a/app/src/main/java/com/larsson/voicenote_android/ui/components/RecordingMenuItemCollapsed.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/ui/components/RecordingMenuItemCollapsed.kt
@@ -1,5 +1,6 @@
 package com.larsson.voicenote_android.ui.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,16 +19,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.larsson.voicenote_android.ui.theme.SpaceGroteskFontFamily
+import com.larsson.voicenote_android.ui.theme.VoiceNoteTheme
 
 @Composable
-fun RecordingMenuItemBase(
+fun RecordingMenuItemCollapsed(
+    id: String,
     title: String,
     date: String,
     duration: String,
     isFirstItem: Boolean,
+    onClickExpandContainer: (recordingId: String) -> Unit,
 ) {
     val roundedCornerShape = RoundedCornerShape(
         topStart = 8.dp,
@@ -37,7 +42,11 @@ fun RecordingMenuItemBase(
     )
 
     Card(
-        modifier = Modifier.wrapContentHeight(),
+        modifier = Modifier
+            .wrapContentHeight()
+            .clickable() {
+                onClickExpandContainer(id)
+            },
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background),
         elevation = CardDefaults.cardElevation(),
         shape = if (isFirstItem) roundedCornerShape else RectangleShape,
@@ -79,5 +88,17 @@ fun RecordingMenuItemBase(
                 )
             }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewRecordingItemCollapsed() {
+    VoiceNoteTheme() {
+        RecordingMenuItemCollapsed(
+            title = "A lil recording", date = "2025-04-03", duration = "00:50", isFirstItem = false,
+            id = "",
+            onClickExpandContainer = {}
+        )
     }
 }

--- a/app/src/main/java/com/larsson/voicenote_android/ui/components/RecordingsList.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/ui/components/RecordingsList.kt
@@ -35,7 +35,6 @@ internal fun RecordingsList(
                     date = recording.date,
                     id = recording.id,
                     durationText = recording.duration,
-                    onToggleExpandContainer = { uiAudioPlayerClickListener.onToggleExpandContainer(recording.id) },
                     isFirstItem = if (isMenu) index < 1 else false, // top item will have rounded corners in menu component
                     onClickPlay = { uiAudioPlayerClickListener.onClickPlay(recording) },
                     onClickDelete = { uiAudioPlayerClickListener.onClickDelete(recording.id) },

--- a/app/src/main/java/com/larsson/voicenote_android/ui/theme/Theme.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/ui/theme/Theme.kt
@@ -1,10 +1,13 @@
 package com.larsson.voicenote_android.ui.theme // ktlint-disable filename
 
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.text.selection.LocalTextSelectionColors
+import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
@@ -49,6 +52,15 @@ fun VoiceNoteTheme(
         colorScheme = appColorScheme,
         typography = AppTypography,
         shapes = AppShapes,
-        content = content,
-    )
+    ) {
+        val textSelectionColors = TextSelectionColors(
+            handleColor = appColorScheme.onBackground,
+            backgroundColor = appColorScheme.onBackground.copy(alpha = 0.4f)
+        )
+
+        CompositionLocalProvider(
+            LocalTextSelectionColors provides textSelectionColors,
+            content = content
+        )
+    }
 }

--- a/app/src/main/java/com/larsson/voicenote_android/ui/theme/Type.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/ui/theme/Type.kt
@@ -2,6 +2,7 @@ package com.larsson.voicenote_android.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -9,7 +10,7 @@ import androidx.compose.ui.unit.sp
 import com.larsson.voicenote_android.R
 
 val SpaceGroteskFontFamily = FontFamily(
-    androidx.compose.ui.text.font.Font(resId = R.font.space_grotesk_variable_fontwght),
+    Font(resId = R.font.space_grotesk_variable_fontwght),
 )
 
 // Set of Material typography styles to start with
@@ -22,6 +23,11 @@ val AppTypography = Typography(
     bodySmall = TextStyle(
         fontFamily = SpaceGroteskFontFamily,
         fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+    ),
+    labelSmall = TextStyle(
+        fontFamily = SpaceGroteskFontFamily,
+        fontWeight = FontWeight.W700,
         fontSize = 14.sp,
     ),
     titleLarge = TextStyle(

--- a/app/src/main/java/com/larsson/voicenote_android/viewmodels/interfaces/AudioPlayerEvent.kt
+++ b/app/src/main/java/com/larsson/voicenote_android/viewmodels/interfaces/AudioPlayerEvent.kt
@@ -1,13 +1,14 @@
 package com.larsson.voicenote_android.viewmodels.interfaces
+
 import com.larsson.voicenote_android.data.repository.Recording
 
 sealed interface AudioPlayerEvent {
     data class Play(val recording: Recording) : AudioPlayerEvent
     data class Delete(val recordingId: String) : AudioPlayerEvent
     object Pause : AudioPlayerEvent
-    object SetToIdle : AudioPlayerEvent
     data class SeekTo(val position: Float) : AudioPlayerEvent
-    data class ToggleExpanded(
+    data class ExpandContainer(
         val recordingId: String,
     ) : AudioPlayerEvent
+    data class OnTitleValueChange(val title: String, val recordingId: String) : AudioPlayerEvent
 }


### PR DESCRIPTION
Implements inline text editing for recording titles in the expanded player view.

**Changes:**
- Add editable BasicTextField to replace static title text
- Implement Room database update query for recording titles
- Save title changes on component disposal to minimize DB writes
- Add global text selection colors matching app theme
- Refactor container expansion logic for clarity

Closes #19