### PR TITLE
Fix: Notification player not responding to taps

### DIFF
--- a/audioplayer/src/main/java/com/larsson/voicenote_android/audioplayer/PlaybackService.kt
+++ b/audioplayer/src/main/java/com/larsson/voicenote_android/audioplayer/PlaybackService.kt
@@ -1,5 +1,7 @@
 package com.larsson.voicenote_android.audioplayer
 
+import android.app.PendingIntent
+import android.os.Build
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
@@ -10,7 +12,20 @@ class PlaybackService : MediaSessionService() {
     override fun onCreate() {
         super.onCreate()
         val player = ExoPlayer.Builder(this).build()
-        mediaSession = MediaSession.Builder(this, player).build()
+
+        val intent = packageManager.getLaunchIntentForPackage(packageName)
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+        val pendingIntent = intent?.let {
+            PendingIntent.getActivity(this, 0, it, flags)
+        }
+
+        mediaSession = MediaSession.Builder(this, player)
+            .apply { pendingIntent?.let { setSessionActivity(it) } }
+            .build()
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = mediaSession


### PR DESCRIPTION
Adds PendingIntent configuration to MediaSession so tapping the media notification now opens the app.

**Changes:**
- Configure MediaSession with session activity PendingIntent in PlaybackService
- Dynamically resolve launcher activity using packageManager
- Add proper FLAG_IMMUTABLE support for Android M+ (API 23+)

Fixes #24